### PR TITLE
Agregar lint scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "start": "babel-node index.js",
     "couples": "babel-node couples.js",
+    "lint": "standard; exit 0;",
+    "lint:fix": "standard --fix",
     "teams": "babel-node teams.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Le agregué `exit 0;` al comando para que npm no tire su famoso error al final y se pierda el output del linter.